### PR TITLE
Getexecresult

### DIFF
--- a/iotex/client.go
+++ b/iotex/client.go
@@ -61,6 +61,10 @@ type client struct {
 	api iotexapi.APIServiceClient
 }
 
+func (c *client) API() iotexapi.APIServiceClient {
+	return c.api
+}
+
 func (c *client) ReadOnlyContract(contract address.Address, abi abi.ABI) ReadOnlyContract {
 	return &readOnlyContract{
 		address: contract,
@@ -71,6 +75,13 @@ func (c *client) ReadOnlyContract(contract address.Address, abi abi.ABI) ReadOnl
 
 func (c *client) GetReceipt(actionHash hash.Hash256) GetReceiptCaller {
 	return &getReceiptCaller{
+		api:        c.api,
+		actionHash: actionHash,
+	}
+}
+
+func (c *client) GetExecutionResult(actionHash hash.Hash256) GetExecutionResultCaller {
+	return &getExecutionResultCaller{
 		api:        c.api,
 		actionHash: actionHash,
 	}

--- a/iotex/interfaces.go
+++ b/iotex/interfaces.go
@@ -40,6 +40,11 @@ type GetReceiptCaller interface {
 	Call(ctx context.Context, opts ...grpc.CallOption) (*iotexapi.GetReceiptByActionResponse, error)
 }
 
+// GetExecutionResultCaller is used to perform a get execution result call.
+type GetExecutionResultCaller interface {
+	Call(ctx context.Context, opts ...grpc.CallOption) ([]byte, error)
+}
+
 // AuthedClient is an iotex client which associate with an account credentials, so it can perform write actions.
 type AuthedClient interface {
 	ReadOnlyClient
@@ -51,8 +56,11 @@ type AuthedClient interface {
 
 // ReadOnlyClient is an iotex client which can perform read actions.
 type ReadOnlyClient interface {
+	API() iotexapi.APIServiceClient
+
 	ReadOnlyContract(contract address.Address, abi abi.ABI) ReadOnlyContract
 	GetReceipt(actionHash hash.Hash256) GetReceiptCaller
+	GetExecutionResult(actionHash hash.Hash256) GetExecutionResultCaller
 }
 
 // ReadContractCaller is used to perform a read contract call.

--- a/iotex/iotex_test.go
+++ b/iotex/iotex_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/stretchr/testify/require"
 
+	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-antenna-go/v2/account"
 	"github.com/iotexproject/iotex-proto/golang/iotexapi"
@@ -100,4 +101,38 @@ func TestReadContract(t *testing.T) {
 
 	_, err = c.ReadOnlyContract(contract, abi).Read("get").Call(context.Background())
 	require.NoError(err)
+}
+
+func TestGetReceipt(t *testing.T) {
+	require := require.New(t)
+
+	conn, err := NewDefaultGRPCConn(_mainnet)
+	require.NoError(err)
+	defer conn.Close()
+
+	c := NewReadOnlyClient(iotexapi.NewAPIServiceClient(conn))
+
+	h, err := hash.HexStringToHash256("f322902f272ee9f8d716ee843e7e1edd426ba4d37ef715b8430ee34f5b40bc75")
+	require.NoError(err)
+	res, err := c.GetReceipt(h).Call(context.Background())
+	require.NoError(err)
+	require.Equal("8715ffa12a776c6bfc9c04ba904ca5ff21c0a25e369ae1262a246b1e02b3e9cf", res.ReceiptInfo.BlkHash)
+	require.Equal(uint64(1), res.ReceiptInfo.Receipt.Status)
+	require.Equal(uint64(378583), res.ReceiptInfo.Receipt.BlkHeight)
+	require.Equal("f322902f272ee9f8d716ee843e7e1edd426ba4d37ef715b8430ee34f5b40bc75", hex.EncodeToString(res.ReceiptInfo.Receipt.ActHash))
+}
+
+func TestGetExecutionResult(t *testing.T) {
+	require := require.New(t)
+	conn, err := NewDefaultGRPCConn(_mainnet)
+	require.NoError(err)
+	defer conn.Close()
+
+	c := NewReadOnlyClient(iotexapi.NewAPIServiceClient(conn))
+
+	h, err := hash.HexStringToHash256("edf65e7ccbfb05e4fbd394db1acc276029c309994879e3a8c07023a753ea8886")
+	require.NoError(err)
+	res, err := c.GetExecutionResult(h).Call(context.Background())
+	require.NoError(err)
+	require.NotNil(res)
 }


### PR DESCRIPTION
1. GetExeuctionResult() is same as V1's ReadContractByHash()
2. simplify Contract(), ReadOnlyContract(), Transfer() input to string