### PR TITLE
added encodeArguements to convert string address to ethereum address

### DIFF
--- a/iotex/callers.go
+++ b/iotex/callers.go
@@ -416,21 +416,11 @@ func encodeArgument(method abi.Method, args []interface{}) ([]interface{}, error
 	newArgs := make([]interface{}, len(args))
 	for index, input := range method.Inputs {
 		if input.Type.String() == "address" {
-			str, ok := args[index].(string)
-			if !ok {
-				addr, check := args[index].(address.Address)
-				if !check {
-					return nil, errcodes.New("fail to convert from interface to string or ioAddress", errcodes.InvalidParam)
-				}
-				newArgs[index] = common.HexToAddress(hex.EncodeToString(addr.Bytes()))
-				continue
-			}
-			ioAddress, err := address.FromString(str)
+			var err error
+			newArgs[index], err = addressTypeAssert(args[index])
 			if err != nil {
-				return nil, errcodes.New("fail to convert string to ioAddress", errcodes.InvalidParam)
+				return nil, errcodes.NewError(err, errcodes.InvalidParam)
 			}
-			newArgs[index] = common.HexToAddress(hex.EncodeToString(ioAddress.Bytes()))
-
 		} else if input.Type.String() == "address[]" {
 			s := reflect.ValueOf(args[index])
 			if s.Kind() != reflect.Slice && s.Kind() != reflect.Array {
@@ -438,20 +428,11 @@ func encodeArgument(method abi.Method, args []interface{}) ([]interface{}, error
 			}
 			newArr := make([]common.Address, s.Len())
 			for j := 0; j < s.Len(); j++ {
-				str, ok := s.Index(j).Interface().(string)
-				if !ok {
-					addr, check := s.Index(j).Interface().(address.Address)
-					if !check {
-						return nil, errcodes.New("fail to convert from interface to string or ioAddress", errcodes.InvalidParam)
-					}
-					newArgs[index] = common.HexToAddress(hex.EncodeToString(addr.Bytes()))
-					continue
-				}
-				ioAddress, err := address.FromString(str)
+				var err error
+				newArr[j], err = addressTypeAssert(s.Index(j).Interface())
 				if err != nil {
-					return nil, errcodes.New("fail to convert from string to ioAddress", errcodes.InvalidParam)
+					return nil, errcodes.NewError(err, errcodes.InvalidParam)
 				}
-				newArr[j] = common.HexToAddress(hex.EncodeToString(ioAddress.Bytes()))
 			}
 			newArgs[index] = newArr
 		} else {
@@ -459,4 +440,21 @@ func encodeArgument(method abi.Method, args []interface{}) ([]interface{}, error
 		}
 	}
 	return newArgs, nil
+}
+
+func addressTypeAssert(preVal interface{}) (common.Address, error) {
+	switch v := preVal.(type) {
+	case string:
+		ioAddress, err := address.FromString(v)
+		if err != nil {
+			return common.Address{}, errcodes.New("fail to convert string to ioAddress", errcodes.InvalidParam)
+		}
+		return common.HexToAddress(hex.EncodeToString(ioAddress.Bytes())), nil
+	case address.Address:
+		return common.HexToAddress(hex.EncodeToString(v.Bytes())), nil
+	case common.Address:
+		return v, nil
+	default:
+		return common.Address{}, errcodes.New("fail to convert from interface to string/ioAddress/ethAddress", errcodes.InvalidParam)
+	}
 }

--- a/iotex/callers.go
+++ b/iotex/callers.go
@@ -415,13 +415,14 @@ func encodeArgument(method abi.Method, args []interface{}) ([]interface{}, error
 	}
 	newArgs := make([]interface{}, len(args))
 	for index, input := range method.Inputs {
-		if input.Type.String() == "address" {
+		switch input.Type.String() {
+		case "address":
 			var err error
 			newArgs[index], err = addressTypeAssert(args[index])
 			if err != nil {
 				return nil, errcodes.NewError(err, errcodes.InvalidParam)
 			}
-		} else if input.Type.String() == "address[]" {
+		case "address[]":
 			s := reflect.ValueOf(args[index])
 			if s.Kind() != reflect.Slice && s.Kind() != reflect.Array {
 				return nil, errcodes.New("fail because the type is non-slice, non-array", errcodes.InvalidParam)
@@ -435,7 +436,7 @@ func encodeArgument(method abi.Method, args []interface{}) ([]interface{}, error
 				}
 			}
 			newArgs[index] = newArr
-		} else {
+		default:
 			newArgs[index] = args[index]
 		}
 	}

--- a/iotex/iotex_test.go
+++ b/iotex/iotex_test.go
@@ -180,7 +180,13 @@ func TestExecuteContractWithAddressArgument(t *testing.T) {
 	contract, err := address.FromString("io1up8gd9nxhc0k0fjff7nrl6jn626vkdzj7y3g09")
 	require.NoError(err)
 
-	recipients := [2]string{"io18jaldgzc8wlyfnzamgas62yu3kg5nw527czg37", "io1ntprz4p5zw38fvtfrcczjtcv3rkr3nqs6sm3pj"}
+	recipient1, err := address.FromString("io18jaldgzc8wlyfnzamgas62yu3kg5nw527czg37")
+	require.NoError(err)
+	recipient2, err := address.FromString("io1ntprz4p5zw38fvtfrcczjtcv3rkr3nqs6sm3pj")
+	require.NoError(err)
+
+	recipients := [2]address.Address{recipient1, recipient2}
+	//recipients := [2]string{"io18jaldgzc8wlyfnzamgas62yu3kg5nw527czg37", "io1ntprz4p5zw38fvtfrcczjtcv3rkr3nqs6sm3pj"}
 	amounts := [2]*big.Int{big.NewInt(1), big.NewInt(2)}
 	actionHash, err := c.Contract(contract, abi).Execute("multiSend", recipients, amounts, "payload").SetGasPrice(big.NewInt(1000000000000)).SetGasLimit(1000000).Call(context.Background())
 	require.NoError(err)


### PR DESCRIPTION
When we want to deploy/execute a smart contract with the address/[]address argument, it has to convert string address to ethereum address. 

In deploy, execute, readonexecute, I added encodeArgumen() to convert string to ethAddress 
And added test files including address[] argument 
