### PR TITLE
Support Ethereum typed transactions via TX_CONTAINER encoding

### DIFF
--- a/iotex/callers_typed_test.go
+++ b/iotex/callers_typed_test.go
@@ -185,6 +185,43 @@ func TestCall_TypedTx_RoutesToContainer(t *testing.T) {
 	require.Equal(t, uint64(50000), decoded.Gas())
 }
 
+// TestCall_TypedTx_ActionCoreFieldsPreserved confirms that signContainer does
+// not strip non-ChainID fields from ActionCore (Bug 2 regression guard).
+func TestCall_TypedTx_ActionCoreFieldsPreserved(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	acc, err := account.HexStringToAccount(_rlpTestKey)
+	require.NoError(t, err)
+	to, err := address.FromString(_rlpTestTo)
+	require.NoError(t, err)
+
+	api := mock_iotexapi.NewMockAPIServiceClient(ctrl)
+	var captured *iotextypes.Action
+	api.EXPECT().
+		SendAction(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *iotexapi.SendActionRequest, _ ...grpc.CallOption) (*iotexapi.SendActionResponse, error) {
+			captured = req.GetAction()
+			return &iotexapi.SendActionResponse{ActionHash: strings.Repeat("0", 64)}, nil
+		})
+
+	c := NewAuthedClient(api, _rlpTestChainID, acc)
+	_, err = c.Transfer(to, big.NewInt(1)).
+		SetNonce(7).
+		SetTxType(dynamicFeeTxType).
+		SetGasTipCap(big.NewInt(500000000)).
+		SetGasFeeCap(big.NewInt(1500000000)).
+		SetGasLimit(42000).
+		Call(context.Background())
+	require.NoError(t, err)
+
+	core := captured.GetCore()
+	require.Equal(t, uint64(7), core.GetNonce())
+	require.Equal(t, uint64(42000), core.GetGasLimit())
+	require.Equal(t, "500000000", core.GetGasTipCap())
+	require.Equal(t, "1500000000", core.GetGasFeeCap())
+	require.Equal(t, _rlpTestChainID, core.GetChainID())
+}
+
 // TestSetAccessList_DefensiveCopy confirms mutating the caller's slice after
 // the setter does not change what the SDK will send.
 func TestSetAccessList_DefensiveCopy(t *testing.T) {

--- a/iotex/utils.go
+++ b/iotex/utils.go
@@ -68,13 +68,11 @@ func signContainer(a account.Account, act *iotextypes.ActionCore) (*iotextypes.A
 	if err != nil {
 		return nil, err
 	}
+	act.Action = &iotextypes.ActionCore_TxContainer{
+		TxContainer: &iotextypes.TxContainer{Raw: raw},
+	}
 	return &iotextypes.Action{
-		Core: &iotextypes.ActionCore{
-			ChainID: act.GetChainID(),
-			Action: &iotextypes.ActionCore_TxContainer{
-				TxContainer: &iotextypes.TxContainer{Raw: raw},
-			},
-		},
+		Core:         act,
 		SenderPubKey: a.PublicKey().Bytes(),
 		Signature:    actionSig,
 		Encoding:     iotextypes.Encoding_TX_CONTAINER,


### PR DESCRIPTION
## Summary

- Add support for EIP-1559 (DynamicFee), EIP-2930 (AccessList), EIP-4844 (Blob), and EIP-7702 (SetCode) typed transactions
- Typed txs are signed as raw Ethereum RLP bytes and sent via `TX_CONTAINER` encoding to the node
- `SetCodeAuthorization` uses IoTeX chain IDs (1/2/3) in the public API; internally maps to EVM network IDs (4689/4690/4691)
- **Bug fix**: `signContainer` previously stripped all `ActionCore` fields except `ChainID`; now preserves `Nonce`, `GasLimit`, `GasTipCap`, `GasFeeCap`, and all other fields alongside the `TxContainer`

## Test plan

- [ ] `go test ./iotex/...` — 42 tests pass including `TestCall_TypedTx_ActionCoreFieldsPreserved` (Bug 2 regression guard)
- [ ] Integration tests skip gracefully when `IOTEX_CORE` env is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)